### PR TITLE
Proofreading of most doc pages for Primo

### DIFF
--- a/docs/mpcnc/PBelts.md
+++ b/docs/mpcnc/PBelts.md
@@ -9,12 +9,12 @@
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/HStop2-scaled.jpg){: width="400"}
 
-* The Stop Blocks get stretched over the rails, if for some reason your prints do not flex enough you can slide them on the rails from the end.
-* Make sure to face the screw head opening up so you can get to them with a screw driver later when you are setting the dual endstops.
+* The Stop Blocks get stretched over the rails. If for some reason your prints do not flex enough, you can slide them on the rails from the end.
+* Make sure to face the screw head opening up so you can get to them with a screwdriver later when you are setting the dual endstops.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/HStop3-scaled.jpg){: width="400"}
 
-* The Stop blocks are positioned on the Zero (minimum) end of each axis as shown in this picture.
+* The Stop Blocks are positioned on the zero (minimum) end of each axis as shown in this picture.
 
 ___
 
@@ -22,7 +22,7 @@ ___
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Slide1-scaled.jpg){: width="400"}
 
-* The Upper Belt, Lower Belt, and mirrored versions all function the same way.
+* The Upper Belt, Lower Belt, and Mirrored versions all function the same way.
 * You will need the 8 printed parts and eight M5 nuts.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Slide2-scaled.jpg){: width="400"}
@@ -30,12 +30,12 @@ ___
 * The M5 nut gets slid in with the nylock facing the belt slot as shown.
 
 !!! Tip
-    As with all these Nylocks, pre-threading them once or twice will loosen them up a bit. This helps to prevent splitting the printed nut captures.
+    As with all these nylocks, pre-threading them once or twice will loosen them up a bit. This helps to prevent splitting the printed nut captures.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Slide3-scaled.jpg){: width="400"}
 
 * The nuts fit into the end and are fully captured.
-* You can use a small screw driver to push them into position or pull them into place with a screw.
+* You can use a small screwdriver to push them into position or pull them into place with a screw.
 
 ___
 
@@ -73,11 +73,11 @@ ___
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Final-scaled.jpg){: width="400"}
 
 * Setting the actual tension is not easy to quantify without a special test tool.
-* You want equal tension in all four belts ( 6-10lbs).
+* You want equal tension in all four belts (6-10lbs).
 * The needed tension is much less than most people think. It should just barely make a noise when plucked.
 
 !!! Note
-    Start loose, when using the machine for a cut or plotting the dimensions will be on the small side if the belts are too loose. Easy fix, half turn of the belt  screw.
+    Start loose. When using the machine for a cut or plotting, the dimensions will be on the small side if the belts are too loose. Easy fix - half turn of the belt screw.
     Too tight and you can experience skipped steps randomly, premature wear on the idlers and steppers, the need for increased current to the steppers, and excessive heat. None of these are cheap easy fixes, start on the loose side.
 
 ___

--- a/docs/mpcnc/PParts.md
+++ b/docs/mpcnc/PParts.md
@@ -55,12 +55,12 @@ Color is the default color scheme I use to print the kits. Color `A` is one colo
 Total weight in PLA is approximately 2.2kg.
 
 #### Print time
-Print times have varied from 65hrs (0.5mm nozzle @38mm/s), 120hrs (0.4mm @60+mm/s), 160hrs (0.4mm nozzle @35mm/s).
+Print times have varied from 65hrs (0.5mm nozzle @38mm/s), to 120hrs (0.4mm @60+mm/s), and 160hrs (0.4mm nozzle @35mm/s).
 ___
 
 ## Hardware
 
-The kits in the [V1 Shop](https://shop.v1engineering.com/collections/parts) contain all the following hardware. Currently it is not available separately.
+The kits in the [V1 Shop](https://shop.v1engineering.com/collections/parts) contain all of the following hardware. Currently it is not available separately.
 
 | Hardware     | Alternative | QTY |
 |--------------|-------------|-----|
@@ -75,11 +75,11 @@ ___
 
 ## Components
 
-The kits in the [V1 Shop](https://shop.v1engineering.com/collections/parts) contain all the following components.
+The kits in the [V1 Shop](https://shop.v1engineering.com/collections/parts) contain all of the following components.
 Some of these are affiliate links, you can buy from these links or just use them for information.
 
 !!! note
-    I try to keep the amazon links up to date, but they can sometimes change products without
+    I try to keep the Amazon links up to date, but they can sometimes change products without
     changing the item number. So be careful when looking at these links to compare against
     the offerings in the shop. If you're not sure, drop a question in the forums.
 
@@ -142,5 +142,5 @@ Kits are available in the [V1 Shop](https://shop.v1engineering.com/products/mpcn
 | M2.5x12mm Phillips Pan Head Screws | 10  |
 | *10mm GT2 belt.                    | ?M  |
 
-*While can use your 6mm belt I suggest you upgrade to 10mm belt, use the [calculator](calculator.md) for the amount you need.
+*While you can use your 6mm belt, I suggest you upgrade to 10mm belt. Use the [calculator](calculator.md) for the amount you need.
 

--- a/docs/mpcnc/PZPage.md
+++ b/docs/mpcnc/PZPage.md
@@ -3,8 +3,8 @@
 ## Z Rails
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2015/08/zrail.jpg){: width="400"}
 
-* Using the cut [Calculator](calculator.md) determine your Z rail length.
-* You will need to drill 4 holes for M5 Screws.
+* Using the cut [Calculator](calculator.md), determine your Z rail length.
+* You will need to drill 4 holes for M5 screws.
 * It is best to oversize the holes (up to about 8mm is fine) to allow for some adjustment and non-perfect drilling.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/RailMark-scaled.jpg){: width="400"}
@@ -13,21 +13,21 @@
 * A center punch, center drill, or even filing a small flat spot helps with drilling accuracy.
 
 !!! Tip
-    You can draw a straight line on one rail using the other as a guide or and square block roughly half as high as the rail.
+    You can draw a straight line on one rail using the other as a guide and/or a square block roughly half as high as the rail.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/RailHole-scaled.jpg){: width="400"}
 
-* Deburring the edges of the holes assures good tool mount alignment.
+* Deburring the edges of the holes ensures good tool mount alignment.
 ___
 
-## LeadScrew
+## Leadscrew
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/T8Parts-scaled.jpg){: width="400"}
 
-* This step requires a Stepper, 5mm to 8mm coupler, and your Leadscrew.
+* This step requires a stepper, 5mm to 8mm coupler, and your leadscrew.
 
 !!! Note
-    The cut calculator give you a minimum screw length. The maximum screw length is the end of the Z rails when you axis is fully assembled.
+    The cut calculator give you a minimum screw length. The maximum screw length is the end of the Z rails when your axis is fully assembled.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/T8Assm-scaled.jpg){: width="400"}
 
@@ -36,20 +36,20 @@ ___
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2018/07/Coupler-use.jpg){: width="400"}
 
-This is how these couplers should be used. The coupler should not be compressed, if anything a little stretch to make sure the lead screw is in contact with the stepper shaft. This prevents bouncing. The lead screw should be only inserted as far as the coupler bottom collar. This lets the stepper shaft and lead screw move for any minor misalignment.
+* This is how these couplers should be used. The coupler should not be compressed; if anything, a little stretch to make sure the lead screw is in contact with the stepper shaft - this prevents bouncing. The lead screw should only be inserted as far as the coupler bottom collar. This lets the stepper shaft and leadscrew move for any minor misalignment.
 
-Seat the grub screws on the shaft trying to get the straightest connection possible. If you hit an edge of a thread it will get wonky just give it a little turn and try again. On the stepper shaft tighten the flat screw first then the one that hits the round surface.
+* Seat the grub screws on the shaft trying to get the straightest connection possible. If you hit an edge of a thread it will get wonky; just give it a little turn and try again. On the stepper shaft, tighten the flat screw first then the one that hits the round surface.
 
 ## Stepper
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/StepParts-scaled.jpg){: width="400"}
 
-* This step uses 4 M3x10mm screws, the printed Z Motor part, and the previous leadscrew assembly
+* This step uses 4 M3x10mm screws, the printed Z Motor part, and the previous leadscrew assembly.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/StepAssm-scaled.jpg){: width="400"}
 
-* Snug down all 4 screws
-* These stepper screws are easy to cross thread, take it slow and do not force anything.
+* Snug down all 4 screws.
+    * These stepper screws are easy to cross thread, take it slow and do not force anything.
 
 ## Thrust Block
 
@@ -59,21 +59,21 @@ Seat the grub screws on the shaft trying to get the straightest connection possi
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/ThrustAssm-scaled.jpg){: width="400"}
 
-* Seat the bearing, the top should be flush with the part.
+* Seat the bearing - the top should be flush with the part.
 
-## Z axis
+## Z Axis
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Z1-scaled.jpg){: width="400"}
 
-* You will need all the previous assemblies from this step.
+* You will need all of the previous assemblies from this step.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Z2-scaled.jpg){: width="400"}
 
-* Pay attention to the direction the Z coupler part is facing. Face the bearing towards the coupler. They will end up touching.
+* Pay attention to the direction the Z Coupler part is facing. Face the bearing towards the coupler. They will end up touching.
 * Slide both rails in. The holes you drilled angle in and are on the same end.
 
 !!! info
-    The lower Z coupler part stays just above the middle holes to help with alignment. Don't push it
+    The lower Z Coupler part stays just above the middle holes to help with alignment. Don't push it
     all together yet.
 
 * The stepper assembly should be flush with the top of the Z rails.
@@ -90,23 +90,23 @@ Seat the grub screws on the shaft trying to get the straightest connection possi
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/NutAssm-scaled.jpg){: width="400"}
 
 * Pay attention to the direction the nylocks are facing.
-* Seat the nuts in fully
+* Seat the nuts in fully.
 * A drop of glue is a good idea here. These are blind nuts and that prevents them from getting pushed out.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Z3-scaled.jpg){: width="400"}
 
-* Slide the nut traps into the rails. Pointy end first.
+* Slide the Nut Traps into the rails. Pointy end first.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Z4-scaled.jpg){: width="400"}
 
-* The bottoms of the nuts traps should be flush with the bottoms of the Z rails and the holes aligned.
+* The bottoms of the Nut Traps should be flush with the bottoms of the Z rails and the holes aligned.
 
 ## Tool Mount
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Mount1-scaled.jpg){: width="400"}
 
-* For this step you will need your tool mount of choice, and 2-4 M5 screws depending, and both Upper and Lower printed tool plates.
-* This is showing the dewalt 660 mount.
+* For this step you will need your tool mount of choice, 2-4 M5 screws depending on the mount, and both Upper and Lower printed Tool Plates.
+* This is showing the Dewalt 660 mount.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Mount2-scaled.jpg){: width="400"}
 
@@ -120,36 +120,36 @@ Seat the grub screws on the shaft trying to get the straightest connection possi
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Clamp1-scaled.jpg){: width="400"}
 
-* You can now slide the Z coupler part up to the coupler.
-* The Bearing should make contact with the coupler, it prevents the coupler stretching.
+* You can now slide the Z Coupler part up to the coupler.
+* The bearing should make contact with the coupler, it prevents the coupler stretching.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Clamp2-scaled.jpg){: width="400"}
 
-* Snug up the Stepper assembly to the Z rails.
+* Snug up the stepper assembly to the Z rails.
 
 !!! warning
     These are clamping parts so there will be a gap even when the part is tight.
 
-* Very little force is needed here, 4 screws have a lot of holding power and they are only holding a few pounds.
+* Very little force is needed here; 4 screws have a lot of holding power and they are only holding a few pounds.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Clamp3-scaled.jpg){: width="400"}
 
-* Push the bearing plate up to the coupler make sure they are touching.
-* The plates should be parallel and have equal spacing on both sides.
+* Push the bearing plate up to the coupler and make sure they are touching.
+    * The plates should be parallel and have equal spacing on both sides.
 * Snug up the plate.
 
 !!! Warning
-     You can get plate too tight and make the leadscrew hard to rotate. So once you have finished this step make sure the coupler moves easily with your fingers.
+     You can get the plate too tight and make the leadscrew hard to rotate. Once you have finished this step, make sure the coupler moves easily with your fingers.
 
 ## Z Core
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/ZCoreP-scaled.jpg){: width="400"}
 
-* For this step you will need 4 nuts and bolts, all four Core Z Clamp printed parts.
+* For this step you will need 4 nuts and bolts, and all four Core Z Clamp printed parts.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/ZCoreAssm-scaled.jpg){: width="400"}
 
-* The Core Z Clamps have a angled edge that should match the angled edge on the Core itself.
+* The Core Z Clamps have an angled edge that should match the angled edge on the Core itself.
 
 !!! warning
     These bolts need to be extremely loose, only turn to _just_ get the nylocks engaged.
@@ -161,10 +161,10 @@ Seat the grub screws on the shaft trying to get the straightest connection possi
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/ZCoreAdj-scaled.jpg){: width="400"}
 
 * Very carefully start to tighten each clamp.
-* You want each bearing to be in contact with the rail but you should just be able to rotate the bearing with your fingers.
-* 1/16th of a turn here can be drastic. Take your time.
+    * You want each bearing to be in contact with the rail but you should just be able to rotate the bearing with your fingers.
+    * 1/16th of a turn here can be drastic. Take your time.
 * You want each bearing to be in equal tension. This flexes the Core properly and keeps the Z axis perpendicular to the work surface.
-* Over tightening is detrimental. Again, loose is better than tight.
+    * Over tightening is detrimental. Again, loose is better than tight.
 * Move the axis up and down and check for free movement through the entire range.
 
 !!! Tip

--- a/docs/mpcnc/Pbase.md
+++ b/docs/mpcnc/Pbase.md
@@ -56,7 +56,7 @@ ___
 * This next diagonal should match the previous one. Squaring this way can be extremely accurate because any error in the leg locations is multiplied in this measurement.
 * Adjust both rear legs until you are satisfied with the precision.
 * Screw in one foot at a time, minor adjustments are possible.
-* Triple check the diagonals they need to be as close as you can get them.
+* Triple check the diagonals - they need to be as close as you can get them.
 
 !!! Tip
     Marking and pre-drilling the foot hold downs in the center of the screw slots makes it much easier to get a square base and leaves a tiny bit of room for adjustment.
@@ -66,12 +66,12 @@ ___
 ## Leg Locks
 ![!Parts and hardware](https://www.v1engineering.com/wp-content/uploads/2020/06/lock-parts-scaled.jpg){: width="400"}
 
-* You will need the Printed Corner Leg Locks and M5 Luck nuts.
+* You will need the printed Corner Leg Locks and M5 locknuts.
 * It is best to pre-thread all the locknuts before assembly. This will loosen them and prevent mangling of the printed parts.
 
-![!Embeded nut](https://www.v1engineering.com/wp-content/uploads/2020/06/lock-ready-scaled.jpg){: width="400"}
+![!Embedded nut](https://www.v1engineering.com/wp-content/uploads/2020/06/lock-ready-scaled.jpg){: width="400"}
 
-* Push the nut into the Leg lock and fully seat it. If it does not stay on it's own you can use a drop of Glue.
+* Push the nut into the Corner Leg Lock and fully seat it. If it does not stay on it's own you can use a drop of glue.
 * If the nut does not stay on it's own, you can attach the Corner Bottom very loosely with its bolt.
 
 ![!Orientation](https://www.v1engineering.com/wp-content/uploads/2020/06/base-lock-scaled.jpg){: width="400"}
@@ -85,19 +85,19 @@ ___
 ## Corner Bottoms
 ![!Parts and hardware](https://www.v1engineering.com/wp-content/uploads/2020/06/corner-bottom-scaled.jpg){: width="400"}
 
-* You will need the printed Corner Bottoms and Corner Bottom Mirrored And M5x30 screws.
+* You will need the printed Corner Bottoms and Corner Bottom Mirrored and M5x30 screws.
 
 !!! Warning
     If you are not using the V1 Kit please make sure your screw heads are low profile enough not to interfere with the Lower Rail.
 
 ![!Belt Orientation](https://www.v1engineering.com/wp-content/uploads/2020/06/base-bottom-arrows-scaled.jpg){: width="400"}
 
-* The corner bottoms go on the leg locks as shown, Pay attention to how the belt slider slots are oriented. They point towards each other on the outside of the build area.
+* The Corner Bottoms go on the Leg Locks as shown. Pay attention to how the belt slider slots are oriented. They point towards each other on the outside of the build area.
 * This picture is taken with the 0,0 (home) corner in the bottom nearest left. The corners should be as shown.
 
 ![!Assemble](https://www.v1engineering.com/wp-content/uploads/2020/06/base-bottom-scaled.jpg){: width="400"}
 
-* Get the screws started to hold the leg locks and corner bottoms together.
+* Get the screws started to hold the Leg Locks and Corner Bottoms together.
 * Leave them loose, just tight enough to make the screw head clear the rail.
 
 ![!Add Y rails](https://www.v1engineering.com/wp-content/uploads/2020/06/rails-1-scaled.jpg){: width="400"}
@@ -109,13 +109,13 @@ ___
 ## Lock The Legs
 ![!Hardware needded](https://www.v1engineering.com/wp-content/uploads/2020/06/leglock1-scaled.jpg){: width="400"}
 
-* You will need four sets of the M5 screws and Locknuts.
-* It is best to pre-thread all the locknuts before assembly. This will loosen them and prevent mangaling of the printed parts.
+* You will need four sets of the M5 screws and locknuts.
+* It is best to pre-thread all the locknuts before assembly. This will loosen them and prevent mangling of the printed parts.
 
 ![!Snugged up Lock](https://www.v1engineering.com/wp-content/uploads/2020/06/leglock2-scaled.jpg){: width="400"}
 
-* Snug up all four leg locks.
-* Snug, is just that, 1/4 turn past the screw and nut seating into the part. Just tight enough to make the corner have some resistance if you try to take it off the leg. 
+* Snug up all four Leg Locks.
+* Snug is just that, 1/4 turn past the screw and nut seating into the part. Just tight enough to make the corner have some resistance if you try to take it off the leg. 
 * All clamping parts have a gap. ***Do not clamp it hard enough to close the gap***!
 
 ![!Assemble](https://www.v1engineering.com/wp-content/uploads/2020/06/base-bottom-scaled.jpg){: width="400"}
@@ -123,7 +123,7 @@ ___
 * Now remove the rails and snug up the screw in the bottom of the corner pieces.
 
 !!! Tip
-    This screw is tightened after the leg locks so the bottom corner will correctly and fully seat on the angled joint between the two parts. If you tighten the bottom first you might have a hard time locking the leg into place or the bottom corner could come loose.
+    This screw is tightened after the Leg Locks so the Corner Bottom will correctly and fully seat on the angled joint between the two parts. If you tighten the bottom first you might have a hard time locking the leg into place or the Corner Bottom could come loose.
 ___
 
 ## Leveling
@@ -149,4 +149,4 @@ ___
 
 ___
 
-Done With the Base! 
+Done with the Base! 

--- a/docs/mpcnc/Ptable.md
+++ b/docs/mpcnc/Ptable.md
@@ -2,7 +2,7 @@
 ## A Quick and Dirty Table
 
 You can really use any table you have, the sturdier the better of course. If you don’t have a spare
-table your willing to get really dirty, here is one I put together for a few dollars worth of 2×4’s.
+table your willing to get really dirty, here is one I put together for a few dollars worth of 2×4's.
 
 ![!Table Structure](https://www.v1engineering.com/wp-content/uploads/2015/10/IMG_20151022_175857.jpg){: width="400"}
 
@@ -17,7 +17,7 @@ ___
  
 ## GeoDave at it again! – parametric table
 
-[GeoDAve's table on Thingiverse](http://www.thingiverse.com/thing:1468511)
+[GeoDave's table on Thingiverse](http://www.thingiverse.com/thing:1468511)
 
 ## MPTable??
 

--- a/docs/mpcnc/calculator.md
+++ b/docs/mpcnc/calculator.md
@@ -34,7 +34,7 @@ highly** recommend that. More sizing details on [this page](https://www.v1engine
 
 !!! note "* Tool Choice"
     Larger tools may collide with the side rails and restrict movement
-    before the MPCNC reaches its full range of motion in x and y.
+    before the MPCNC reaches its full range of motion in X and Y.
     Select your intended tool to account for this difference in the following dimensions:
 
 ----

--- a/docs/mpcnc/core.md
+++ b/docs/mpcnc/core.md
@@ -6,27 +6,27 @@ ___
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreBZ1-scaled.jpg){: width="400"}
 
 !!! note
-    Take these steps in order. The core is very dependent on the order of assembly.
+    Take these steps in order. The Core is very dependent on the order of assembly.
 
 * You will need 4 bolts, nuts, bearings, and the Core printed part
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreBZ2-scaled.jpg){: width="400"}
 
 * Snap the bearings into the slots.
-* You can line them up and give them a tap with the ratchet handle and they should pop into place.
-* This is intentional to add rigidity.
+    * You can line them up and give them a tap with the ratchet handle and they should pop into place.
+    * This is intentional to add rigidity.
 
 !!! Hint
-    If you pop the bearings in too far or need to get them out the rear has a hole for a Allen key to push them back out.
+    If you pop the bearings in too far or need to get them out, the rear has a hole for an Allen key to push them back out.
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreBZ3-scaled.jpg){: width="400"}
 
-* Paying attention to the direction of the bolt heads insert the bolts and nuts.
-* Snug these bolts up, just 1/16th of a turn past seated (touching the plastic on both sides)
+* Paying attention to the direction of the bolt heads, insert the bolts and nuts.
+* Snug these bolts up, just 1/16th of a turn past seated (touching the plastic on both sides).
 
 !!! Caution
     Ratchets are dangerous here. We only need 7in/lbs or so. It is next to nothing. Loose is better
-    then too tight. That is true for all of these steps.
+    than too tight. That is true for all of these steps.
 
 ___
 
@@ -53,9 +53,9 @@ ___
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreXY2-scaled.jpg){: width="400"}
 
-* This first one is the Core Clamp**Y**
+* This first one is the Core Clamp**Y**.
 * The flat side faces towards the logo and needs to be in this location.
-* The Core ClampY is specifically made to clear a bolt head on the Truck
+* The Core ClampY is specifically made to clear a bolt head on the Truck.
 * Two bearings are at an angle between the Core and Core Clamp. Insert the top bearing and bolt first, then the bottom.
 
 !!! note
@@ -63,13 +63,13 @@ ___
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreXY3-scaled.jpg){: width="400"}
 
-* Add All 4 Sets
-* Snug up all these bolts, 7in/lbs, just past seated, do not crush the 1mm spacers.
+* Add All 4 sets.
+* Snug up all these bolts, 7in/lbs, just past seated. Do not crush the 1mm spacers.
 * Double check the part orientation. Flat sides of the Core Clamps face away from each other.
 * Notice where the Core ClampY part is located.
 
 !!! tip
-    The holes in the Core Clamps are just for you to mount things if you need a spot. The holes fit M5's (or cable ties).
+    The holes in the Core Clamps are just for you to mount things if you need a spot. The holes fit M5s (or cable ties).
 
 ___
 
@@ -81,9 +81,9 @@ ___
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreYZ2-scaled.jpg){: width="400"}
 
-* Slide a bearing in the Core Clamps
-* The bolt heads should all be up, let gravity keep them in place.
-* Do not use a nut yet
+* Slide a bearing in the Core Clamps.
+* The bolt heads should all be up - let gravity keep them in place.
+* Do not use a nut yet.
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreYZ3-scaled.jpg){: width="400"}
 
@@ -91,24 +91,24 @@ ___
 
 ___
 
-## Setting The Gantry Rails
+## Setting the Gantry Rails
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/CoreRail1-scaled.jpg){: width="400"}
 
-* You will need a rail and nuts for each tension bolt
+* You will need a rail and nuts for each tension bolt.
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/Core-Rail2-scaled.jpg){: width="400"}
 
-* Slide the rail in the assembly
+* Slide the rail in the assembly.
 * The rail should have slight tension and feel good with no nuts in place.
-* All the bearings should be making contact
-* If your rail is loose or too tight there could be other issues.
+* All the bearings should be making contact.
+    * If your rail is loose or too tight there could be other issues.
 * At this point, put the nuts on. Carefully seat the nuts just to lock in the current tension.
-* A very light touch is needed here. You will be coming back to these so just seat the bolts and nuts.
+    * A very light touch is needed here. You will be coming back to these so just seat the bolts and nuts.
 * The rails should have a slight drag and feel the same with and without the nuts in place.
 
 !!! Tip
-    More tension is not better. Too loose and too tight are bad. If your rails did not have a good feeling tension like the trucks in the earlier steps please stop and ask in the forums for help.
+    More tension is not better. Too loose and too tight are bad. If your rails did not have a good feeling tension like the Trucks in the earlier steps please stop and ask in the forums for help.
     If the rails feel really tight before adding the tension nuts with the rail in place loosen and tighten the two other nuts and bolts in each Core Clamp. This can give extra room if needed.
 
 ___
@@ -117,24 +117,24 @@ ___
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/TLock1-scaled.jpg){: width="400"}
 
-* Add both gantry rails
-* The open face of the Core should face the 0,0 corner (left nearest corner)
+* Add both gantry rails.
+* The open face of the Core should face the 0,0 corner (left nearest corner).
 
 !!! info
-    Because of the asymmetry of the trucks, if the core doesn't point to 0,0, the work area will be
+    Because of the asymmetry of the Trucks, if the Core doesn't point to 0,0, the work area will be
     smaller.
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/TLock2-scaled.jpg){: width="400"}
 
-* Snug up the Truck Clamps
-* There is a Gap here, same as the clamping parts. Do not try to close the gap.
+* Snug up the Truck Clamps.
+* There is a gap here, same as the clamping parts. Do not try to close the gap.
 * No need to stop the rails from rotating but there should be resistance.
 
 ## Leadscrew Nut
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/Znut1-scaled.jpg){: width="400"}
 
-* You will need the brass T8 Lead Screw Nut and two M3x10 Screws
+* You will need the brass T8 lead screw nut and two M3x10 screws.
 
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/Znut2-scaled.jpg){: width="400"}
 
@@ -144,7 +144,7 @@ ___
 
 !!! Tip
     This has to move to help with the Z screw alignment. Too tight and you can get binding.
-    Another tip is screws as shown in the picture move the nut back (away from them). If you find you are getting some binding try moving the screws to the back instead. Left or right can also work.
+    Another tip is to screw them in as shown in the picture, then move the nut back (away from them). If you find you are getting some binding try moving the screws to the back instead. Left or right can also work.
 
 ___
 ![slow clap](https://media.tenor.co/images/657e144fa560d4ad525ff71651f24a7d/raw)

--- a/docs/mpcnc/intro.md
+++ b/docs/mpcnc/intro.md
@@ -3,7 +3,7 @@
  
 ## The Mostly Printed CNC
 
-The Mostly Printed CNC (MPCNC) is a platform to precisely control motion. This can easily be a milling machine, 3D router, 3D Printer, Laser Cutter, vinyl cutter, CNC plasma cutter, you name it.
+The Mostly Printed CNC (MPCNC) is a platform to precisely control motion. This can easily be a milling machine, 3D router, 3D printer, laser cutter, vinyl cutter, CNC plasma cutter, you name it.
 
 ## Cost
 
@@ -11,12 +11,12 @@ All components are easily sourced or you can buy the parts from this site. Here 
 
 * The [Bundle](https://vicious1-com.myshopify.com/collections/bundles/products/mostly-printed-cnc-parts-bundle) has all the hardware and electronics except the [conduit/rails](https://www.v1engineering.com/assembly/conduit-rails-tubes-pipes/) which are cheaper to source locally than to ship – $271 + shipping if international.
 * 20′ of [Conduit](https://www.v1engineering.com/assembly/conduit-rails-tubes-pipes/) **≈\$12** (or stainless steel tubing for a little more ≈\$43) .
-* Plastic parts, filament, less than 2 spools **≈\$30** if you own a 3D printer, if not buy it from [here](https://shop.v1engineering.com/collections/parts) for $1xx.
+* Plastic parts, filament, less than 2 spools **≈\$30** if you own a 3D printer. If not, buy the printed parts from [here](https://shop.v1engineering.com/collections/parts) for $1xx.
 * Tool. Either a [Dewalt](https://amzn.to/1MoBSQq), [import spindle](https://amzn.to/3dkKgl0) or an [extruder](https://amzn.to/37ZjygN) (3D Printer) $28, or anything else you might want to bolt on, [laser](https://amzn.to/37OcdQK), [drag knife](https://shop.v1engineering.com/collections/parts/products/drag-knife-vinyl-cutter), foam cutting needle (awesome), etc.
 
 Total Cost… if you have a 3D printer **Under $370**, $4xx if you buy the printed parts from here.
 
-I would like to drive that price home one more time, you can have a CNC router for precision work ([here](https://www.v1engineering.com/forum/topic/mrrf-2018-ideas/page/3/#post-56336), [here](https://www.v1engineering.com/forum/topic/pcb-examples/#post-9100) all the way up to [aluminum milling](https://forum.v1engineering.com/t/lionkevs-aluminum-attempts/6047/101?u=vicious1) and [plasma cutting](https://www.v1engineering.com/forum/topic/plasma-build/#post-30714) steel for $4xx. That is all you need to spend, throw in a few endmills and you are still under $500. **There is no other machine more versatile than the Mostly Printed CNC at any price point.**
+I would like to drive that price home one more time. You can have a CNC router for precision work ([here](https://www.v1engineering.com/forum/topic/mrrf-2018-ideas/page/3/#post-56336), [here](https://www.v1engineering.com/forum/topic/pcb-examples/#post-9100) all the way up to [aluminum milling](https://forum.v1engineering.com/t/lionkevs-aluminum-attempts/6047/101?u=vicious1) and [plasma cutting](https://www.v1engineering.com/forum/topic/plasma-build/#post-30714) steel for $4xx. That is all you need to spend, throw in a few endmills and you are still under $500. **There is no other machine more versatile than the Mostly Printed CNC at any price point.**
 
 
 ## Specs…

--- a/docs/mpcnc/squaring.md
+++ b/docs/mpcnc/squaring.md
@@ -5,18 +5,18 @@
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/OverHead-scaled.jpg){: width="400"}
 
 * This step is just to get the gantry rails as perpendicular to each other as possible.
-* The more square your build the more accurate your cuts.
-* Previously you squared your base, then the Trucks to the base, now you are squaring the Core. If you use dual endstop firmware you will be able to dial this in even further.
+* The more square your build, the more accurate your cuts.
+* Previously you squared your base, then the Trucks to the base, and now you are squaring the Core. If you use dual endstop firmware you will be able to dial this in even further.
 * Machine accuracy is much easier to achieve with the Primo version.
 
 ## Test
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/NearSide-scaled.jpg){: width="400"}
 
-* An easy test is to measure and compare the trucks as they sit.
+* An easy test is to measure and compare the Trucks as they sit.
 * You should have no belts attached at this point.
 * Move the gantry around by hand, and place it roughly in the center of your work area.
-* Measure each truck pair without moving the gantry in the process.
+* Measure each Truck pair without moving the gantry in the process.
 
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/FarSide-scaled.jpg){: width="400"}
@@ -30,7 +30,7 @@
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/OverHead-Diagram-scaled.jpg){: width="400"}
 
 * Start with whichever gantry rail has the most error.
-* Tightening a core clamp will move the rail and truck away from that bolt. 
+* Tightening a Core Clamp will move the rail and Truck away from that bolt. 
 * The outer Core Clamps have the largest effect.
 * Use small adjustments. 1/16th of a turn at a time.
 * After each adjustment move the gantry around and test the Truck pair distances again.
@@ -38,8 +38,8 @@
 
 !!! Tip
     This should be very small adjustments and you are looking to get them within 1mm. If you
-    over tighten them they stop moving. So if the trucks are showing no effect, loosen the tension
-    bolts all the way and start again. The minimum tension was set in the core building step,
+    over tighten them they stop moving. So if the Trucks are showing no effect, loosen the tension
+    bolts all the way and start again. The minimum tension was set in the Core building step,
     so you will begin by tightening the clamps. At some point you can also loosen them a bit for the
     opposite effect.
 

--- a/docs/mpcnc/tops.md
+++ b/docs/mpcnc/tops.md
@@ -19,16 +19,16 @@ ___
 ![!Primo layout](https://www.v1engineering.com/wp-content/uploads/2020/06/XYDiagram-scaled.jpg){: width="400"}
 
 * Use this picture to orient the Trucks and sort out your X and Y rails
-* You do not need the Gantry rails at this point, they are just in this picture to clarify the position of the trucks.
+* You do not need the gantry rails at this point, they are just in this picture to clarify the position of the Trucks.
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Rails-scaled.jpg){: width="400"}
 
 * Add the tops.
-* Pay close attention to the belt slides they should be on the opposite rails of the corner bottom parts.
+* Pay close attention to the belt slides they should be on the opposite rails of the Corner Bottom parts.
 * Add the screws and nuts and lightly seat them all. 
 
 !!! Caution
-    With all the captured nuts you should prethread the screws at least once to loosen the lock nuts up a bit to not destroy the printed parts.
+    With all the captured nuts you should prethread the screws at least once to loosen the locknuts up a bit to not destroy the printed parts.
 
 
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Gap-scaled.jpg){: width="400"}
@@ -39,20 +39,21 @@ ___
 * Do not over tighten these screws.
 
 !!! Caution
-    The corner parts are the most commonly over tightened and broken pieces on both CNC's. There is absolutely no need. You can always add tension if there was a problem but cracking a part requires printing or buying a new one. ***Remember, there is no need to stop the rails from rotating***. 
+    The corner parts are the most commonly over tightened and broken pieces on both CNCs. There is absolutely no need. You can always add tension if there was a problem but cracking a part requires printing or buying a new one. ***Remember, there is no need to stop the rails from rotating***. 
 
 ___
 
 ## Truck Squaring
 ![!MPCNC stationary bearings](https://www.v1engineering.com/wp-content/uploads/2020/06/Truck-squaring.png){: width="400"}
 
-* New to the Primo Version, before moving on it is best to square your trucks.
-* Clamp in your Gantry rails.
+* New to the Primo version, before moving on it is best to square your Trucks.
+* Clamp in your gantry rails.
 * Move the axis around to settle it.
-* Measure from the trucks on the same axis to either corner. (yellow Arrow)
-* Now you can move the trucks by very slightly tightening the tension bolts, start small try 1/16th of a turn. (green arrows)
-* Too tight and it will stop moving.
-* Loosening will relax it opposite the green arrows.
+* Measure from the Trucks on the same axis to either corner (yellow arrow).
+* Now you can move the Trucks by very slightly tightening the tension bolts. 
+    * Start small: try 1/16th of a turn (green arrows).
+    * Too tight and it will stop moving.
+    * Loosening will relax it opposite the green arrows.
 * Check both axes, again looking for 1mm or under.
 * Remove the gantry rails.
 

--- a/docs/mpcnc/trucks.md
+++ b/docs/mpcnc/trucks.md
@@ -5,9 +5,9 @@ Click on the images to embiggen.
 ## Bearings
 ![!MPCNC Truck parts](https://www.v1engineering.com/wp-content/uploads/2020/06/TParts-scaled.jpg){: width="400"}
 
-* You will need 5 sets of 5/16 x 1 1/2" (M8 x 40mm) Bolts and locking nuts.
+* You will need 5 sets of 5/16 x 1 1/2" (M8 x 40mm) bolts and locknuts.
 * Two 1/2" sockets and ratchets (or 13mm for M8's).
-* 5 Bearings.
+* 5 bearings.
 * Printed Truck and Truck Mirrored parts.
 
 ___
@@ -15,8 +15,8 @@ ___
 ## Tension Bolts
 ![!MPCNC truck tension bolts](https://www.v1engineering.com/wp-content/uploads/2020/06/Tension-scaled.jpg){: width="400"}
 
-* Insert the bearings in the truck and fit the bolts.
-* Just seat the locking nut, these will get adjusted later. Leave these loose.
+* Insert the bearings in the Truck and fit the bolts.
+* Just seat the locknuts, they will get adjusted later. Leave them loose.
 
 !!! Note
     Pay attention to the direction of the bolt heads on these two tension bolts.
@@ -37,9 +37,9 @@ ___
 ## Set The Truck Tension
 ![!MPCNC set the tension](https://www.v1engineering.com/wp-content/uploads/2020/06/Set-Tension-scaled.jpg){: width="400"}
 
-* Insert a rail into the truck.
-* You are looking for all bearings to make contact and just a hint of tension. If you tip the rail at a 45 degree angle the trucks should slowly move. Too tight and they will stay, too loose and they will drop right off.
-* Tension bolth bolts evenly, for a new print this should actually just be good with no extra tension needed. If this is the case just snug up the tension bolts until the heads and nuts are touching the plastic. Holding not adding to the current tension.
+* Insert a rail into the Truck.
+* You are looking for all bearings to make contact and just a hint of tension. If you tip the rail at a 45 degree angle the Trucks should slowly move. Too tight and they will stay, too loose and they will drop right off.
+* Tension both bolts evenly - for a new print this should actually just be good with no extra tension needed. If this is the case just snug up the tension bolts until the heads and nuts are touching the plastic. Holding not adding to the current tension.
 
 !!! Caution
        If you have to really torque down on these bolts you could have the wrong sized rails or parts. The same thing applies if they are too tight, although you can let them sit overnight with no tension on the bolts to see if they loosen up a bit.
@@ -48,8 +48,8 @@ ___
 ## Truck Clamp
 ![!MPCNC clamp parts](https://www.v1engineering.com/wp-content/uploads/2020/06/Addclamp-scaled.jpg){: width="400"}
 
-* You will need the printed Truck Clamp's.
-* M5 x 30mm Screw and lock nut.
+* You will need the printed Truck Clamps.
+* M5 x 30mm screw and lock nut.
 * \#2 screwdriver.
 
 ![!MPCNC clamp assembled](https://www.v1engineering.com/wp-content/uploads/2020/06/Looseclamp-scaled.jpg){: width="400"}
@@ -65,9 +65,9 @@ ___
 ## Belts and Idlers
 ![!MPCNC adding belts](https://www.v1engineering.com/wp-content/uploads/2020/06/Add-Belt-scaled.jpg){: width="400"}
 
-* You will need two idlers for each truck.
-* Two M5 screws and nuts
-* \#2 screw driver
+* You will need two idlers for each Truck.
+* Two M5 screws and nuts.
+* \#2 screw driver.
 
 !!! Tip
     If you add the belts first it is easier than trying to fish them through later. Each axis has a mirrored set of trucks so that is an easy way to also pair up the belts.
@@ -75,7 +75,7 @@ ___
 
 ![!MPCNC adding idlers](https://www.v1engineering.com/wp-content/uploads/2020/06/Idlers-scaled.jpg){: width="400"}
 
-* Tuck in the Idlers into the pocket in the trucks.
+* Tuck in the idlers into the pocket in the Trucks.
 * Tighten the screws just tight enough to seat the nut all the way then back off a 1/2 turn.
 * Ensure the idlers are free spinning.
 
@@ -96,12 +96,12 @@ ___
 ![!MPCNC aligning the drive train](https://www.v1engineering.com/wp-content/uploads/2020/06/Pulley-3.jpg){: width="400"}
 
 * Make sure the pulley is aligned with the idlers.
-* (optional) add loctite to the grub screws, even a bit on the stepper shaft can help.
+* (optional) Add loctite to the grub screws, even a bit on the stepper shaft can help.
 * Tighten the grub screw on the stepper shaft flat first.
 * Tighten the second grub screw.
 
 !!! Tip
-    Loose pulleys are probably the number one issue we see on both the MPCNC and LowRider CNC builds. They cause all sort of erratic behavior and false "skipped steps". Take your time do this correctly. Notice it does not say tighten the heck out of them. Get them on in the right order, directly on the flat, and loctite is your friend.
+    Loose pulleys are probably the number one issue we see on both the MPCNC and LowRider CNC builds. They cause all sort of erratic behavior and false "skipped steps". Take your time and do this correctly. Notice it does not say tighten the heck out of them. Get them on in the right order, directly on the flat, and loctite is your friend.
 
 ___
 

--- a/docs/mpcnc/trucks.md
+++ b/docs/mpcnc/trucks.md
@@ -70,7 +70,7 @@ ___
 * \#2 screw driver.
 
 !!! Tip
-    If you add the belts first it is easier than trying to fish them through later. Each axis has a mirrored set of Trucks so that is an easy way to also pair up the belts.
+    If you add the belts first it is easier than trying to fish them through later. Each axis has a mirrored set of Trucks, so that is an easy way to also pair up the belts.
 
 
 ![!MPCNC adding idlers](https://www.v1engineering.com/wp-content/uploads/2020/06/Idlers-scaled.jpg){: width="400"}

--- a/docs/mpcnc/trucks.md
+++ b/docs/mpcnc/trucks.md
@@ -70,7 +70,7 @@ ___
 * \#2 screw driver.
 
 !!! Tip
-    If you add the belts first it is easier than trying to fish them through later. Each axis has a mirrored set of trucks so that is an easy way to also pair up the belts.
+    If you add the belts first it is easier than trying to fish them through later. Each axis has a mirrored set of Trucks so that is an easy way to also pair up the belts.
 
 
 ![!MPCNC adding idlers](https://www.v1engineering.com/wp-content/uploads/2020/06/Idlers-scaled.jpg){: width="400"}
@@ -86,12 +86,12 @@ ___
 
 * Steppers
 * Pulleys
-* Wire Darryl / Pulley spacer
+* Wire Darryl / pulley spacer
 * (optional) [Loctite](https://shop.v1engineering.com/collections/miscellaneous/products/0-5ml-threadlocker-242)
 
 ![!MPCNC set the pulleys](https://www.v1engineering.com/wp-content/uploads/2020/06/Pulley2-scaled.jpg){: width="400"}
 
-* You can use the wire darryl to set the pulley height or just do it by eye in the next step.
+* You can use the Wire Darryl to set the pulley height or just do it by eye in the next step.
 
 ![!MPCNC aligning the drive train](https://www.v1engineering.com/wp-content/uploads/2020/06/Pulley-3.jpg){: width="400"}
 


### PR DESCRIPTION
Mostly spelling/grammar changes and capitalization changes for printed part names. In some cases I made steps sub-bullets because they were guidance.