### PR TITLE
Update milling-basics.md

### DIFF
--- a/docs/tools/milling-basics.md
+++ b/docs/tools/milling-basics.md
@@ -233,13 +233,19 @@ Estlcam
 :   Built in, Christian was happy to work with us to get this correct. [Here are the recommended
 settings](../software/estlcam-basics.md)
 
-Fusion360
-:   Guffy has really made what seems to be a feature complete PP here, [Guffy’s
+Fusion360:
+
+Guffy has really made what seems to be a feature complete PP here, [Guffy’s
 GitHub](https://github.com/guffy1234/mpcnc_posts_processor). [Fusion CAM
 intro](https://www.youtube.com/watch?v=Do_C_NLH5sw).
 
+Flyfisher604 has created an enhanced Post Processor (available here [Flyfisher604/mpcnc_post_processor](https://github.com/flyfisher604/mpcnc_post_processor)) based on Guffy's PP. The Flyfisher604 post processor addresses the issues introduced by the F360 Hobby version. This includes:
+- scaling of feedrates to resolve MPCNC's max Z feedrate being less then XY max cut rate,
+- recovery of the G0 Rapid that moves to the starting location of the cut,
+- recovery of G0 Rapids that occur at a safe level above the work.
+
 !!! warning
-    Fusion's free plan no longer supports more than one speed, so the feedrate for XY turn into very fast Z movements. More details in the forum [here](https://forum.v1engineering.com/t/problem-with-fusion-and-z-feedrate/21487)
+    Fusion's free plan no longer supports more than one speed, so the feedrate for XY turn into very fast Z movements. More details in the forum [here](https://forum.v1engineering.com/t/problem-with-fusion-and-z-feedrate/21487). Using the Flyfisher604 PP with scaling enabled can resolve this issue.
 
 !!! warning
     (10/23/19) Do not use arcs unless you are using 417 or newer firmware.


### PR DESCRIPTION
I have decided to make a version of the post processor available in addition to guffy's. I created several pull requests against guffy's post processor and never got any feedback. While guffy has a beta that has some similar enhancements it is also got issues that are unresolved. Guffy provides no Issue support on his Github so there is no where to provide feedback.

I look forward to enhancing this new code base moving forward.

As the doc update says the new PP resolves 3 significant issues created by the hobby version of F360: (1) no separate feedrates for Z vs XY, no G0 Rapid to the starting cut position, the loss of all G0 Rapids. The enhanced PP resolves this by scaling feedrates, detecting the missing positioning move, and restoring G0s that are at a safe Z. 