### PR TITLE
Added DW660 Pen Holder

### DIFF
--- a/docs/software/estlcam-basics.md
+++ b/docs/software/estlcam-basics.md
@@ -139,6 +139,6 @@ things this type of mill is used for. Make sure to adjust your tool and its sett
 the material in use. Always do a test cut!
 
 Here is an old video, the [new pen holder](https://www.thingiverse.com/thing:1612207) has a built in
-spring so you will get even more consistent results.
+spring so you will get even more consistent results; or if you already have a DW660 router mount installed and don't want to remove it, then use this [DW660 Primo Pen Holder Mount](https://www.thingiverse.com/thing:4681654) with the same spring feature.
 
 [!embed](https://www.youtube.com/watch?v=s8YwkcK3P9U)


### PR DESCRIPTION
I have added a link to my pen holder that can drop into the DW660 mount, avoiding have to unbolt from the Primo's Z axis rails.

It has been downloaded 18 times from Thingiverse since Dec 11, 2020. 

Q: Didn't want to edit the original text but is the "new pen holder" still new? Doesn't it link to a pen holder for a version prior to Primo? I think I saw that Ryan had a newer one but I can't seem to find it again.