### PR TITLE
ZenXY image is broken on MarlinBuilder releases

### DIFF
--- a/docs/electronics/marlin-firmware.md
+++ b/docs/electronics/marlin-firmware.md
@@ -69,7 +69,7 @@ rough idea of which configurations have the most users and the most testing.
 
 ## ZenXY Configurations
 
-![!FirstZenXY](https://www.v1engineering.com/wp-content/uploads/2017/07/IMG_20170717_103443.jpg){: width="450"}
+![!FirstZenXY](https://www.v1engineering.com/wp-content/uploads/2021/03/XZXY-V2F-squarer.jpg){: width="450"}
 
 ### Ultimachine
 


### PR DESCRIPTION
The image was broken on the MarlinBuilder releases page for the ZenXY. This should fix it, I hope. 

Check to make sure this is the image you want. There is also one of your dining room table on your Shopify.