### PR TITLE
Annotating the dimensions of the representative rendering and drawing.

### DIFF
--- a/docs/lowrider/calculator.md
+++ b/docs/lowrider/calculator.md
@@ -2,9 +2,9 @@
 
 # LowRider v3 Size Calculator
 
+(The photo and drawing below are sized for a 48"x96" available cutting area.)
+
 ![!LR3 Fancy Picture](../img/lr3/LR3_Render.png){: loading=lazy width="600"}
-
-
 
 ![!LR3 Dimensions Picture](../img/lr3/LR3 Dims.jpg){: loading=lazy width="600"}
 


### PR DESCRIPTION
I'm at the point in the build where I need to size the X gantry and came to the calculator.  For the drawing and picture, I needed to understand the size context of the rendering and drawing.  It wasn't difficult, but giving a frame of reference size can be helpful.