### PR TITLE
LR3 Calc, round Strut Len to nearest 1mm, NOT 10mm!

### DIFF
--- a/docs/lowrider/calculator.md
+++ b/docs/lowrider/calculator.md
@@ -180,7 +180,7 @@ function clip(value) {
 
 function convertToMetric(num) {
   var units = $("input[name=units]:checked").val();
-  return (units == "mm") ? num : (Math.round(num * 25.4 * 0.1) / 0.1);
+  return (units == "mm") ? num : Math.floor(num * 25.4);
 }
 
 function reset_work() {
@@ -230,7 +230,7 @@ function from_working() {
   $("span[name=xtable]").text(clip(xtable));
   $("span[name=ytable]").text(clip(ytable));
   $("span[name=strut]").text(clip(xrails));
-  updateDownloadStrutLink(Math.round(convertToMetric(xrails)));
+  updateDownloadStrutLink(convertToMetric(xrails));
 }
 
 function download_svg()
@@ -244,7 +244,7 @@ function download_svg()
   var folder = strutSvgFolderPrefix + ((xrailsMetric < 1000) ? "0" : "1" );
   var strutUrl = strutUrlTemplate
     .replace("{folder}", folder)
-    .replace("{len}", Math.round(xrailsMetric));
+    .replace("{len}", xrailsMetric);
 
   window.open(
     strutUrl,


### PR DESCRIPTION
LR3 Calc, round Strut Len to nearest 1mm, NOT 10mm!

BONUS: Using Math.Floor instead of Math.Round, so for fractional mm differences, the Strut is rounded down to nearest mm, and should be never be longer than Tube/Conduit.

Let me know if additional millimeter(s) should be removed from Strut length to account for Maker's LR3 build variance/tolerance.  