### PR TITLE
lowrider: fix Files header

### DIFF
--- a/docs/lowrider/index.md
+++ b/docs/lowrider/index.md
@@ -48,7 +48,9 @@ More details to my loosened restrictions can be found here on [the home page](ht
 
 ![!LR3 Fancy Picture](../img/lr3/LR3_Fancy (4).jpg){: loading=lazy width="600"}
 
-### Files can be found at the links below
+### Files
+
+Printed parts files can be found at the links below:
 
 Printables.com
 :   [Printables.com Link](https://www.printables.com/model/204709-lowrider-3-cnc)


### PR DESCRIPTION
A sentence is used in the table of contents which is confusing:

![Capture](https://user-images.githubusercontent.com/305679/206873642-161bc9db-0da5-47f8-92d5-f0d587580751.JPG)

This PR renames it to 'Files', which is also shorter to link, e.g. `https://docs.v1engineering.com/lowrider/#files`.