### PR TITLE
Modify documentation to correct number of x rails required.

### DIFF
--- a/docs/lowrider/calculator.md
+++ b/docs/lowrider/calculator.md
@@ -43,7 +43,7 @@ Printed Plates are 9.5mm (0.374"), Shop Aluminum plates are 6.35mm (0.25").
 #### Tube Lengths
 |Length (<span class="units">mm</span>)| Qty | Name |
 |--------------------------------------|-----|------|
-|<span name="xrails"     ></span>|2|X rails, also the strut plate width|
+|<span name="xrails"     ></span>|3|X rails, also the strut plate width|
 |<span name="yrail"     ></span>|1|Y rail (for looks you might want to match your table length)|
 
 #### Belt Dimensions


### PR DESCRIPTION
Three x rails are required for the build, not two as indicated.